### PR TITLE
Add include_label_in_id option

### DIFF
--- a/nodestream_plugin_neptune/ingest_query_builder.py
+++ b/nodestream_plugin_neptune/ingest_query_builder.py
@@ -116,6 +116,9 @@ def _convert_unsupported_values(props: dict):
 
 
 class NeptuneIngestQueryBuilder:
+    def __init__(self, include_label_in_id: bool = True):
+        self.include_label_in_id = include_label_in_id
+
     @cache
     @correct_parameters
     def generate_update_node_operation_query_statement(
@@ -172,7 +175,8 @@ class NeptuneIngestQueryBuilder:
         # Todo: What if no keys were given? Maybe let neptune decides.
         # On uniqueness and keys in Neptune, see Schema Constraints in https://docs.aws.amazon.com/neptune/latest/userguide/migration-compatibility.html
         composite_key = "_".join([str(node.key_values[k]) for k in node.key_values])
-        composite_key = f"{node.type}_{composite_key}"
+        if self.include_label_in_id:
+            composite_key = f"{node.type}_{composite_key}"
         return {generate_prefixed_param_name("id", name): composite_key}
 
     @cache

--- a/nodestream_plugin_neptune/neptune_connector.py
+++ b/nodestream_plugin_neptune/neptune_connector.py
@@ -23,6 +23,7 @@ class NeptuneConnector(DatabaseConnector, alias="neptune"):
         mode: str,
         host: str = None,
         graph_id: str = None,
+        include_label_in_id: bool = True,
         **client_kwargs
     ):
         """
@@ -34,6 +35,8 @@ class NeptuneConnector(DatabaseConnector, alias="neptune"):
             Used with mode="database", specify the endpoint of the target Neptune database cluster
         graph_id : str, optional
             Used with mode="analytics", specify the graph identifier of the target Neptune Analytics graph
+        include_label_in_id : bool, optional
+            Sets if the labels should be included in generated node ids. Default is True
         client_kwargs : optional
             Additional keyword arguments to be passed to the boto3 client constructor
         """
@@ -42,7 +45,7 @@ class NeptuneConnector(DatabaseConnector, alias="neptune"):
             mode=mode,
             host=host,
             graph_id=graph_id,
-            ingest_query_builder=NeptuneIngestQueryBuilder(),
+            ingest_query_builder=NeptuneIngestQueryBuilder(include_label_in_id),
             **client_kwargs
         )
 

--- a/tests/unit/test_ingest_query_builder.py
+++ b/tests/unit/test_ingest_query_builder.py
@@ -250,3 +250,47 @@ def test_relationship_update_generates_expected_queries(
         equal_to_ignoring_whitespace(expected_query.query_statement),
     )
     assert_that(query.parameters, equal_to(expected_query.parameters))
+
+
+def test_node_update_with_label_excluded_from_id():
+    query_builder: NeptuneIngestQueryBuilder = NeptuneIngestQueryBuilder(include_label_in_id=False)
+
+    expected_query: QueryBatch = QueryBatch(
+        COMPLEX_NODE_TWO_EXPECTED_QUERY.query_statement,
+        [
+            {
+                "__node_id": "foo_bar",
+                **convert_timestamps(COMPLEX_NODE_TWO.properties),
+            }
+        ],
+    )
+
+    test_node_update_generates_expected_queries(
+        query_builder=query_builder,
+        node=COMPLEX_NODE_TWO,
+        expected_query=expected_query,
+        node_creation_rule=NodeCreationRule.EAGER
+    )
+
+
+def test_relationship_update_with_label_excluded_from_id():
+    query_builder: NeptuneIngestQueryBuilder = NeptuneIngestQueryBuilder(include_label_in_id=False)
+
+    expected_query: QueryBatch = QueryBatch(
+        RELATIONSHIP_BETWEEN_TWO_NODES_EXPECTED_QUERY_WITH_MULTI_KEY_AND_CREATE.query_statement,
+        [
+            {
+                "__from_node_id": "foo",
+                "__to_node_id": "foo_bar",
+                **convert_timestamps(
+                    RELATIONSHIP_BETWEEN_TWO_NODES_WITH_MULTI_KEY_AND_CREATE.relationship.properties
+                ),
+            }
+        ],
+    )
+
+    test_relationship_update_generates_expected_queries(
+        query_builder=query_builder,
+        rel=RELATIONSHIP_BETWEEN_TWO_NODES_WITH_MULTI_KEY_AND_CREATE,
+        expected_query=expected_query,
+    )

--- a/tests/unit/test_neptune_connector.py
+++ b/tests/unit/test_neptune_connector.py
@@ -101,3 +101,20 @@ def test_analytics_must_not_have_host():
             "A `host` should not be used with Neptune Analytics, `graph_id=<Graph Identifier>` should be used instead. If using Neptune Database, set `mode='database'."
         ),
     )
+
+
+def test_include_label_in_id():
+    connector: NeptuneConnector = NeptuneConnector.from_file_data(
+        mode="database",
+        host="testEndpoint.com",
+        include_label_in_id=False
+    )
+    assert_that(connector.ingest_query_builder.include_label_in_id, equal_to(False))
+
+
+def test_include_label_in_id_default_true():
+    connector: NeptuneConnector = NeptuneConnector.from_file_data(
+        mode="database",
+        host="testEndpoint.com"
+    )
+    assert_that(connector.ingest_query_builder.include_label_in_id, equal_to(True))


### PR DESCRIPTION
Currently, the generated node ids are the concatenation of the label and all key values. This results in an id such as `Person_John_Doe`. We've received some requests to make the label optional, to simplify the id to just `John_Doe`. I have added a new `include_label_in_id` config option (defaulting to True) to configure this behavior.

I'm open to suggestions on alternative names for this new option.