### PR TITLE
update nodestream to the latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-nodestream = "^0.12.0"
+nodestream = "^0.12.3"
 cymple = "^0.11.0"
 aiobotocore = "^2.12.0"
 botocore = ">=1.34.40"


### PR DESCRIPTION
Ran into error message
```
GraphDatabaseWriter.from_connector() missing 3 required positional arguments: 'ingest_strategy_name', 'collect_stats', and 'batch_size'
```
and fixed by updating to Nodestream versions 0.12.1+