### PR TITLE
Improved error messages in Neptune Connection

### DIFF
--- a/nodestream_plugin_neptune/neptune_connection.py
+++ b/nodestream_plugin_neptune/neptune_connection.py
@@ -4,6 +4,7 @@ import random
 from abc import ABC, abstractmethod
 from logging import getLogger
 
+import botocore
 from aiobotocore.session import get_session
 
 
@@ -17,19 +18,32 @@ class NeptuneConnection(ABC):
         max_retries = 3
         retry_delay = 1
 
-        async with self._create_boto_client() as client:
-            try:
-                response = await self.__retry(
-                    func=lambda: self.__attempt_query(client, query_stmt, parameters),
-                    max_retries=max_retries,
-                    delay=retry_delay,
-                    exceptions=self._get_retryable_exceptions(client),
-                )
+        try:
+            async with self._create_boto_client() as client:
+                try:
+                    response = await self.__retry(
+                        func=lambda: self.__attempt_query(client, query_stmt, parameters),
+                        max_retries=max_retries,
+                        delay=retry_delay,
+                        exceptions=self._get_retryable_exceptions(client),
+                    )
 
-            except Exception as e:
-                self.logger.exception(f"Unexpected error: {e} for query: {query_stmt}.")
-
-        return response
+                except botocore.exceptions.EndpointConnectionError as e:
+                    self.logger.error(f"\nFailed to connect to database: {e}")
+                    try:
+                        child_error = e.kwargs['error']
+                        self.logger.error(child_error)
+                    except Exception:
+                        pass
+                except botocore.exceptions.NoCredentialsError as e:
+                    self.logger.error(f"\nUnexpected error: {e}.")
+                except client.exceptions.AccessDeniedException as e:
+                    self.logger.error(f"\nUnexpected error: {e}.")
+                except Exception as e:
+                    self.logger.error(f"\nUnexpected error: {e} for query: {query_stmt}.")
+            return response
+        except botocore.exceptions.NoRegionError as e:
+            self.logger.error(f"\nUnexpected error: {e}.")
 
     @abstractmethod
     def _create_boto_client(self):

--- a/nodestream_plugin_neptune/neptune_connection.py
+++ b/nodestream_plugin_neptune/neptune_connection.py
@@ -35,9 +35,7 @@ class NeptuneConnection(ABC):
                         self.logger.error(child_error)
                     except Exception:
                         pass
-                except botocore.exceptions.NoCredentialsError as e:
-                    self.logger.error(f"\nUnexpected error: {e}.")
-                except client.exceptions.AccessDeniedException as e:
+                except (botocore.exceptions.NoCredentialsError, client.exceptions.AccessDeniedException) as e:
                     self.logger.error(f"\nUnexpected error: {e}.")
                 except Exception as e:
                     self.logger.error(f"\nUnexpected error: {e} for query: {query_stmt}.")


### PR DESCRIPTION
The old error messages printed out the entire stack and was cluttering messages. Certain errors were missing information so the relevant information was added to the error messages.
Tested all of the error cases against Neptune DB and Neptune analytics.