### PR TITLE
Make UNWIND partition size configurable

### DIFF
--- a/nodestream_plugin_neptune/neptune_connector.py
+++ b/nodestream_plugin_neptune/neptune_connector.py
@@ -24,6 +24,7 @@ class NeptuneConnector(DatabaseConnector, alias="neptune"):
         graph_id: str = None,
         include_label_in_id: bool = True,
         region: str = None,
+        partition_size: int = NeptuneQueryExecutor.DEFAULT_PARTITION_SIZE,
         **client_kwargs
     ):
         """
@@ -39,6 +40,9 @@ class NeptuneConnector(DatabaseConnector, alias="neptune"):
             Sets if the labels should be included in generated node ids. Default is True
         region : str
             Sets the region of the Neptune graph
+        partition_size : int, optional
+            Number of records per UNWIND query. Default is 150. Neptune Analytics
+            targets may benefit from larger values (e.g., 1000-5000).
         client_kwargs : optional
             Additional keyword arguments to be passed to the boto3 client constructor
         """
@@ -49,6 +53,7 @@ class NeptuneConnector(DatabaseConnector, alias="neptune"):
             graph_id=graph_id,
             ingest_query_builder=NeptuneIngestQueryBuilder(include_label_in_id),
             region=region,
+            partition_size=partition_size,
             **client_kwargs
         )
 
@@ -59,6 +64,7 @@ class NeptuneConnector(DatabaseConnector, alias="neptune"):
         host: str = None,
         graph_id: str = None,
         region: str = None,
+        partition_size: int = NeptuneQueryExecutor.DEFAULT_PARTITION_SIZE,
         **client_kwargs
     ) -> None:
         if mode == "database":
@@ -76,12 +82,14 @@ class NeptuneConnector(DatabaseConnector, alias="neptune"):
         self.host = host
         self.graph_id = graph_id
         self.region = region
+        self.partition_size = partition_size
         self.ingest_query_builder = ingest_query_builder
 
     def make_query_executor(self) -> QueryExecutor:
         return NeptuneQueryExecutor(
             connection=self.connection,
             ingest_query_builder=self.ingest_query_builder,
+            partition_size=self.partition_size,
         )
 
     def make_type_retriever(self, **kwargs) -> TypeRetriever:

--- a/nodestream_plugin_neptune/neptune_query_executor.py
+++ b/nodestream_plugin_neptune/neptune_query_executor.py
@@ -20,13 +20,17 @@ from .query import Query, QueryBatch
 
 
 class NeptuneQueryExecutor(QueryExecutor):
+    DEFAULT_PARTITION_SIZE = 150
+
     def __init__(
         self,
         connection: NeptuneConnection,
         ingest_query_builder: NeptuneIngestQueryBuilder,
+        partition_size: int = DEFAULT_PARTITION_SIZE,
     ) -> None:
         self.database_connection = connection
         self.ingest_query_builder = ingest_query_builder
+        self.partition_size = partition_size
         self.logger = getLogger(self.__class__.__name__)
 
     async def upsert_nodes_in_bulk_with_same_operation(
@@ -60,16 +64,8 @@ class NeptuneQueryExecutor(QueryExecutor):
         await self.execute(Query(query_string, params))
 
     def _split_parameters(self, parameters: list):
-        """
-        Our current understanding is that a partition_size of 100 - 200
-        per batch request will yield the best results. Though this is not a hard rule.
-
-        More investigation on performance is needed.
-        """
-        partition_size = 150
-
-        for i in range(0, len(parameters), partition_size):
-            yield {"params": parameters[i : i + partition_size]}
+        for i in range(0, len(parameters), self.partition_size):
+            yield {"params": parameters[i : i + self.partition_size]}
 
     async def query(self, query_stmt: str, parameters):
         return await self.database_connection.execute(query_stmt, parameters)

--- a/tests/unit/test_query_executor.py
+++ b/tests/unit/test_query_executor.py
@@ -104,3 +104,30 @@ async def test_query_method_exists_and_returns_response(query_executor):
 
     assert response == expected_response
     query_executor.database_connection.execute.assert_awaited_once()
+
+
+def test_default_partition_size(query_executor):
+    assert query_executor.partition_size == NeptuneQueryExecutor.DEFAULT_PARTITION_SIZE
+
+
+def test_custom_partition_size(mocker):
+    executor = NeptuneQueryExecutor(
+        mocker.AsyncMock(NeptuneConnection),
+        mocker.Mock(),
+        partition_size=5000,
+    )
+    assert executor.partition_size == 5000
+
+
+def test_split_parameters_uses_partition_size(mocker):
+    executor = NeptuneQueryExecutor(
+        mocker.AsyncMock(NeptuneConnection),
+        mocker.Mock(),
+        partition_size=3,
+    )
+    params = [{"id": i} for i in range(7)]
+    chunks = list(executor._split_parameters(params))
+    assert len(chunks) == 3
+    assert len(chunks[0]["params"]) == 3
+    assert len(chunks[1]["params"]) == 3
+    assert len(chunks[2]["params"]) == 1


### PR DESCRIPTION
Closes #38 

Adds `partition_size` as a configurable connector option, passed through `NeptuneConnector` → `NeptuneQueryExecutor`. Default remains 150 for backward compatibility.

Usage in `nodestream.yaml`:

```yaml
targets:
  neptune-analytics:
    connector: neptune
    mode: analytics
    graph_id: g-xxxxxxxxxx
    partition_size: 5000
```

### Changes
- `neptune_query_executor.py` - `partition_size` param on `__init__`, replaces hardcoded value in `_split_parameters`
- `neptune_connector.py` - passes `partition_size` from config through to query executor
- `test_query_executor.py` - 3 new tests

### Tested
- Unit tests: 67 passed
- End-to-end: `nodestream copy` NDB → NA with `partition_size: 5000` showed ~2x throughput improvement over the default 150
```